### PR TITLE
Nette coding standard

### DIFF
--- a/returns.php
+++ b/returns.php
@@ -4,7 +4,7 @@ declare(strict_types=0);
 
 class Test
 {
-    function foo($int) : int
+    function foo($int): int
     {
         return 1;
     }

--- a/spaceship.php
+++ b/spaceship.php
@@ -2,7 +2,7 @@
 
 $items = [6, 4, 2, 0];
 
-usort($items, function (int $a, int $b) : int {
+usort($items, function (int $a, int $b): int {
     return $a <=> $b;
 });
 


### PR DESCRIPTION
There must not be any space between `)` and `:` when declaring return types.
